### PR TITLE
Missing object reference for chaining

### DIFF
--- a/speedometer-reusable/js/speedometer.js
+++ b/speedometer-reusable/js/speedometer.js
@@ -176,4 +176,5 @@ $.fn.myfunc = function (userPref) {
   }
   this.creatHtmlsElecments();
   $(this).bind(this.defaultProperty.eventListenerType,this.changePosition);
+  return this;
 }


### PR DESCRIPTION
Returned the object reference within the plugin for chaining function.